### PR TITLE
Corrections by Jeff Warner (jmw202)

### DIFF
--- a/course-info.md
+++ b/course-info.md
@@ -3,41 +3,40 @@ Software Engineering
 
 ## Course Information
 
-**Taught by:** Bill Laboon (laboon@cs.pitt.edu)  
+**Taught by:** Bill Laboon ([laboon@cs.pitt.edu](mailto:laboon@cs.pitt.edu))  
 
 **Professor's Office Hours:**
 
-* SENSQ 6305
-* Wednesday 1:30 - 4:30  PM
-* ...or by appointment.  
+  * SENSQ 6305
+  * Wednesday 1:30 - 4:30  PM
+  * ...or by appointment.  
 
 **Class Time:** TH 11:00 AM - 12:15 PM
 **Room:** SENSQ 5129
 
-**Class GitHub repo:** https://www.github.com/laboon/cs1530  
+**Class GitHub repo:** [https://www.github.com/laboon/cs1530_Fall2016](https://www.github.com/laboon/cs1530_Fall2016)  
 
 **Required Texts:** 
-* Growing Object-Oriented Software, Guided by Tests.  Authors: Steve Freeman and Nat Pryce. ISBN 9780321503626
+  * Growing Object-Oriented Software, Guided by Tests.  Authors: Steve Freeman and Nat Pryce. ISBN 9780321503626
 
-* Code Complete (Second Edition). Author: Steve McConnell. ISBN 0790145196705
+  * Code Complete (Second Edition). Author: Steve McConnell. ISBN 0790145196705
 
-* Online essays/articles will also be assigned.
+  * Online essays/articles will also be assigned.
 
-**
 
 This course provides students with a broad understanding of modern software engineering. Although it will cover theory, the emphasis is on providing practical skills in software engineering currently used in industry. To that end, it will cover project and product management, software architecture and design patterns, team communications, and other material relevant to __engineering__ software instead of just __coding__ it.
 
 ## Grading
 
-* Mid-term Exam 1 - 15%
-* Mid-term Exam 2 - 15%
-* Group Project:
-  * Sprint 1 Deliverable - 10%
-  * Sprint 2 Deliverable - 10% 
-  * Sprint 3 Deliverable - 10%
-  * Sprint 4 Deliverable - 10%
-  * Final Deliverable and Presentation - 20%
-* Class Participation - 10% (Exercises and Guest Lecture attendance)
+  * Mid-term Exam 1 - 15%
+  * Mid-term Exam 2 - 15%
+  * Group Project:
+    * Sprint 1 Deliverable - 10%
+    * Sprint 2 Deliverable - 10% 
+    * Sprint 3 Deliverable - 10%
+    * Sprint 4 Deliverable - 10%
+    * Final Deliverable and Presentation - 20%
+  * Class Participation - 10% (Exercises and Guest Lecture attendance)
 
 It is strongly recommended that you come to class each for each lecture.  Material may be presented or covered in class that is not in the reading.  I also expect active participation in class (there will be various projects done in class).  However,  I will only take roll for the class exercise days.  On these days, attendance and participation is mandatory.
 
@@ -80,7 +79,7 @@ Deliverables must be committed to GitHub or GitLab by the beginning of class on 
 
 ## Extra Credit
 
-Bonus points (at the discretion of the instructor) will be given if you give a talk to a a programming meetup or conference.
+Bonus points (at the discretion of the instructor) will be given if you give a talk to a programming meetup or conference.
 
 ## Programming Language Selection
 

--- a/syllabus.md
+++ b/syllabus.md
@@ -15,21 +15,21 @@ Building and Testing With Gradle is available for free online at: http://www2.gr
 ## WEEK 1 (Week of 29 Aug)
 
 ### Class 1 - Introduction: What is Software Engineering?
-* Software Engineering vs Programming vs Computer Science
+  * Software Engineering vs Programming vs Computer Science
 
 ### Class 2 - Overview: Designing a Software Product
 #### __Reading: Brooks, "The Tar Pit" and Brooks, "The Mythical Man-Month" (just the titular essay, not the entire book)__
 #### __ASSIGNED: Group Selection__
-* Why is this difficult?
-* Overview of the Software Development Life Cycle
-* What goes into a software product aside from code?
+  * Why is this difficult?
+  * Overview of the Software Development Life Cycle
+  * What goes into a software product aside from code?
 
 ## WEEK 2 (Week of 5 Sep)
 
 ### Class 1 - An Overview of Software Engineering Methodologies
 #### __Reading: McConnell, Chapters 1 - 3__
-* Waterfall (BDUF), prototyping, incremental, RAD, UP, "Cowboy coding", Agile
-* Our Methodology: Agile/Scrum with TDD
+  * Waterfall (BDUF), prototyping, incremental, RAD, UP, "Cowboy coding", Agile
+  * Our Methodology: Agile/Scrum with TDD
 
 ### Class 2 - An Overview of Software Engineering Methodologies, cont'd
 


### PR DESCRIPTION
Corrected asterisk spacing in markdown, and some links pointed to old locations (re: old cs1530 repo) or are "breaking" markdown convention. Maybe github can handle the existing format but other parsers hold URLs/email addresses to the stricter standard?
